### PR TITLE
Fix latest version detection

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -44,7 +44,7 @@ where /q ninja.exe || (
 rem *** fetch latest release version
 
 if "%ASEPRITE_VERSION%" equ "" (
-  for /F "delims=" %%v in ('"curl -sfL https://api.github.com/repos/aseprite/aseprite/releases/latest | jq .tag_name -r"') do (
+  for /F "delims=" %%v in ('"curl -sfL https://api.github.com/repos/aseprite/aseprite/tags | jq .[0].name -r"') do (
     set ASEPRITE_VERSION=%%v
   )
 )


### PR DESCRIPTION
Upon starting the github action as of recently, the Github API endpoint returned version v1.3.14.2, when the latest tag available was v1.3.14.4. This PR fixes this by moving to the `tags` endpoint and using the `.[0].name` specifier for `jq` to grab the first (latest) `name` result in the array.