### PR TITLE
Remove hardcoded ninja version

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -35,7 +35,7 @@ where /Q cl.exe || (
 rem *** ninja
 
 where /q ninja.exe || (
-  curl -LOsf https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip || exit /b 1
+  curl -LOsf https://github.com/ninja-build/ninja/releases/latest/download/ninja-win.zip || exit /b 1
   %SZIP% x -bb0 -y ninja-win.zip 1>nul 2>nul || exit /b 1
   del ninja-win.zip 1>nul 2>nul
 )


### PR DESCRIPTION
This build system is great, but the ninja version that gets downloaded (if none is detected) is hardcoded to v1.11.0 from May 2022.
This PR makes it always download the latest stable release.